### PR TITLE
Javascript callback modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ***
 
-## [1.0.2] - 2022-07-01
+## [1.1.0] - 2022-07-01
 ### Changed
 - Changed UploadFile function in JavaScriptInterface
     - removed callback as a parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ***
 
+## [1.0.2] - 2022-07-01
+### Changed
+- Changed UploadFile function in JavaScriptInterface
+    - removed callback as a parameter
+    - added upload type as a parameter (possible types : PUT and POST)
+    - a callback will be generated everytime once there is a failure or a success
+    - callback can be listened from javascript using event listener under the name "rapid-web-view-upload-listener"
+    - under callback the javascript client will get object with following attribute { detail: { 'status' : "success",'uploadUrl' : '$uploadUrl','uploadFileName' : '$fileName' } }
+
+- Changed Permission function in JavaScriptInterface
+    - removed callback as a parameter
+    - added permission type as a parameter (possible types : PUT and POST)
+    - a callback will be generated everytime once there is a failure or a success
+    - callback can be listened from javascript using event listener under the name "rapid-web-view-permission-listener"
+    - under callback the javascript client will get object with following attribute { detail: { 'status' : "failure" } }
+
+- Changed method to fetch file from Internal Storage
+
 ## [1.0.1] - 2022-02-22
 ### Changed
 - Made RapidWebViewJSInterface an open class so that it can be overridden / extended

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/RapidWebViewJSInterface.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/RapidWebViewJSInterface.kt
@@ -58,36 +58,38 @@ open class RapidWebViewJSInterface(
             override fun onReceive(context: Context?, intent: Intent) {
                 if (intent.action == BroadcastConstants.NATIVE_CALLBACK_ACTION) {
                     val permission = intent.getStringExtra(BroadcastConstants.PERMISSION)
-                    var callback = intent.getStringExtra(BroadcastConstants.CALLBACK)
-                        ?: "console.log('Callback not passed')"
-                    val data = intent.getStringExtra(BroadcastConstants.UPLOAD)
+                    val uploadUrl = intent.getStringExtra(BroadcastConstants.UPLOADED_URL) ?: ""
+                    val fileName =
+                        intent.getStringExtra(BroadcastConstants.UPLOADED_FILE_NAME) ?: ""
+                    var javaScript = ""
                     when {
                         intent.getStringExtra(BroadcastConstants.UPLOAD)
                             ?.equals(BroadcastConstants.SUCCESS) == true -> {
-                            callback =
-                                "window.dispatchEvent(new CustomEvent('$callback', { detail: { 'status' : \"success\" } }))"
+
+                            javaScript =
+                                "window.dispatchEvent(new CustomEvent('rapid-web-view-upload-listener', { detail: { 'status' : \"success\",'uploadUrl' : '$uploadUrl','uploadFileName' : '$fileName' } }))"
                         }
                         intent.getStringExtra(BroadcastConstants.UPLOAD)
                             ?.equals(BroadcastConstants.FAILURE) == true -> {
-                            callback =
-                                "window.dispatchEvent(new CustomEvent('$callback', { detail: { 'status' : \"failure\" } }))"
+                            javaScript =
+                                "window.dispatchEvent(new CustomEvent('rapid-web-view-upload-listener', { detail: { 'status' : \"failure\" } }))"
                         }
                         intent.getStringExtra(BroadcastConstants.PERMISSION)
                             ?.equals(BroadcastConstants.SUCCESS) == true -> {
-                            callback =
-                                "window.dispatchEvent(new CustomEvent('$callback', { detail: { 'status' : \"success\" } }))"
+                            javaScript =
+                                "window.dispatchEvent(new CustomEvent('rapid-web-view-permission-listener', { detail: { 'status' : \"success\",'permissionList' : '${permission.toString()}' } }))"
                         }
                         intent.getStringExtra(BroadcastConstants.PERMISSION)
                             ?.equals(BroadcastConstants.FAILURE) == true -> {
-                            callback =
-                                "window.dispatchEvent(new CustomEvent('$callback', { detail: { 'status' : \"failure\" } }))"
+                            javaScript =
+                                "window.dispatchEvent(new CustomEvent('rapid-web-view-permission-listener', { detail: { 'status' : \"failure\" } }))"
                         }
                     }
                     webView.post {
                         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-                            webView.evaluateJavascript(callback, null);
+                            webView.evaluateJavascript(javaScript, null);
                         } else {
-                            webView.loadUrl("javascript:(function(){$callback})()");
+                            webView.loadUrl("javascript:(function(){$javaScript})()");
                         }
                     }
                 }
@@ -464,24 +466,12 @@ open class RapidWebViewJSInterface(
      * Opens an activity to request permissions from user
      * @param permissions: List of permissions to request from user
      * @param rationaleText: Text to show on permission dialog
-     * @param callback: This is either a javascript function or url to open once permission
-     * activity is finished. Callback function can receive list of installed apps by embedding
-     * `$params` in the callback string.
-     *
-     * Eg. callback = "javascript: onPermissionReceived($params)"
-     * Once the user responds to the permission request, below function will be run on WebView
-     * "javascript: onPermissionReceived(["permission1", "permission2"])"
-     *
-     * Eg. callback = "https://example.com/api/permissionGranted/?data=$params"
-     * Once the user responds to the permission request, below url will open on WebView
-     * "https://example.com/api/permissionGranted/?data=["permission1", "permission2"]"
      */
     @JavascriptInterface
-    fun requestPermissions(permissions: Array<String>, rationaleText: String, callback: String?) {
+    fun requestPermissions(permissions: Array<String>, rationaleText: String) {
         val intent = Intent(activity, PermissionActivity::class.java)
 
         intent.putExtra("permissionList", permissions)
-        intent.putExtra("callback", callback)
         intent.putExtra("rationalText", rationaleText)
 
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -493,27 +483,15 @@ open class RapidWebViewJSInterface(
      * Open native file upload interface
      * @param fileType type of file to be uploaded. Choices: `doc`, `image`, `video`, `file`
      * @param uploadUrl PUT request Url where file will be uploaded
-     * @param callback: This is either a javascript function or url to open once file upload
-     * activity is finished. Callback function can receive whether upload file succeeded by
-     * embedding `$params` in the callback string.
+     * @param requestMethod: Possible Input is POST & PUT
      *
-     * Eg. callback = "javascript: onFileUpload($params)"
-     * Once the file upload task completes, below function will be run on WebView
-     * "javascript: onFileUpload(true)"
-     *
-     * Eg. callback = "https://example.com/api/fileUploaded/?data=$params"
-     * Once the file upload task completes, below url will be run on WebView
-     * "https://example.com/api/fileUploaded/?data=false"
-     *
-     * TODO: accept upload header data to be passed along with uploadUrl
      */
     @JavascriptInterface
-    fun uploadFile(fileType: String, uploadUrl: String, callback: String?, requestMethod: String?) {
+    fun uploadFile(fileType: String, uploadUrl: String, requestMethod: String?) {
         val intent = Intent(activity, UploadFileActivity::class.java)
 
         intent.putExtra("fileType", fileType)
         intent.putExtra("uploadUrl", uploadUrl)
-        intent.putExtra("callback", callback)
         intent.putExtra("requestMethod", requestMethod)
 
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/PermissionActivity.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/PermissionActivity.kt
@@ -13,7 +13,6 @@ import pub.devrel.easypermissions.EasyPermissions.requestPermissions
 class PermissionActivity : AppCompatActivity(), EasyPermissions.PermissionCallbacks {
     private val rcGenericPermission: Int = 12312
     private lateinit var permissions: Array<String>
-    private var callback: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,7 +21,6 @@ class PermissionActivity : AppCompatActivity(), EasyPermissions.PermissionCallba
         val intent = intent
 
         permissions = intent?.getStringArrayExtra("permissionList") as Array<String>
-        callback = intent?.getStringExtra("callback")
         val rationalText = intent?.getStringExtra("rationalText") ?: "This permission is required"
 
         if (permissions.isEmpty()) {
@@ -45,7 +43,6 @@ class PermissionActivity : AppCompatActivity(), EasyPermissions.PermissionCallba
         val intentBroadcast = Intent(BroadcastConstants.NATIVE_CALLBACK_ACTION)
 
         intentBroadcast.putExtra(BroadcastConstants.PERMISSION, status)
-        intentBroadcast.putExtra(BroadcastConstants.CALLBACK, callback)
         intentBroadcast.putExtra(BroadcastConstants.PERMISSION_LIST, permissions)
 
         LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intentBroadcast)

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileActivity.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileActivity.kt
@@ -10,7 +10,6 @@ import androidx.appcompat.app.AppCompatActivity
 class UploadFileActivity : AppCompatActivity(), BottomSheetDialogInterface {
     private var fileType: String? = ""
     private var uploadUrl: String? = ""
-    private var callback: String? = null
     private var requestMethod: String? = null
 
     @SuppressLint("SourceLockedOrientationActivity")
@@ -25,7 +24,6 @@ class UploadFileActivity : AppCompatActivity(), BottomSheetDialogInterface {
 
         fileType = intent?.getStringExtra("fileType")
         uploadUrl = intent?.getStringExtra("uploadUrl")
-        callback = intent?.getStringExtra("callback")
         requestMethod = intent?.getStringExtra("requestMethod")
 
         if (fileType.isNullOrBlank() || uploadUrl.isNullOrBlank()) {
@@ -36,7 +34,6 @@ class UploadFileActivity : AppCompatActivity(), BottomSheetDialogInterface {
             UploadFileBottomSheet.getInstance(
                 fileType ?: "",
                 uploadUrl ?: "",
-                callback,
                 requestMethod ?: "POST",
                 this
             )

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileActivity.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileActivity.kt
@@ -11,6 +11,7 @@ class UploadFileActivity : AppCompatActivity(), BottomSheetDialogInterface {
     private var fileType: String? = ""
     private var uploadUrl: String? = ""
     private var callback: String? = null
+    private var requestMethod: String? = null
 
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,6 +26,7 @@ class UploadFileActivity : AppCompatActivity(), BottomSheetDialogInterface {
         fileType = intent?.getStringExtra("fileType")
         uploadUrl = intent?.getStringExtra("uploadUrl")
         callback = intent?.getStringExtra("callback")
+        requestMethod = intent?.getStringExtra("requestMethod")
 
         if (fileType.isNullOrBlank() || uploadUrl.isNullOrBlank()) {
             throw IllegalArgumentException("UploadFileActivity requires `fileType` and `uploadUrl` intent data")
@@ -35,6 +37,7 @@ class UploadFileActivity : AppCompatActivity(), BottomSheetDialogInterface {
                 fileType ?: "",
                 uploadUrl ?: "",
                 callback,
+                requestMethod ?: "POST",
                 this
             )
 

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileBottomSheet.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileBottomSheet.kt
@@ -35,6 +35,7 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
     private var callback: String? = null
     private var requestMethod: String? = null
     private var fileUri: String? = null
+    private var fileName: String? = null
 
     private lateinit var activityResultLauncher: ActivityResultLauncher<Intent>
     private lateinit var handlePathOz: HandlePathOz
@@ -49,7 +50,6 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
         fun getInstance(
             fileType: String,
             uploadUrl: String,
-            callback: String?,
             requestMethod: String?,
             bottomSheetDialogInterface: BottomSheetDialogInterface
         ): UploadFileBottomSheet {
@@ -57,7 +57,6 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
 
             uploadResumeChatBottomSheet.fileType = fileType
             uploadResumeChatBottomSheet.uploadUrl = uploadUrl
-            uploadResumeChatBottomSheet.callback = callback
             uploadResumeChatBottomSheet.requestMethod = requestMethod
             uploadResumeChatBottomSheet.bottomSheetDialogInterface = bottomSheetDialogInterface
 
@@ -105,8 +104,8 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
             val serviceIntent = Intent(activity, UploadService::class.java)
             serviceIntent.putExtra("uploadUrl", uploadUrl)
             serviceIntent.putExtra("fileUri", fileUri)
-            serviceIntent.putExtra("callback", callback)
             serviceIntent.putExtra("requestMethod", requestMethod)
+            serviceIntent.putExtra("fileName", fileName)
             activity?.startService(serviceIntent)
 
         }
@@ -227,7 +226,8 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
         if (!pathOz.path?.equals("")) {
             view?.findViewById<Group>(R.id.file_present)?.visibility = View.VISIBLE
             view?.findViewById<Group>(R.id.file_absent)?.visibility = View.GONE
-            view?.findViewById<TextView>(R.id.tv_file_name)?.text = File(pathOz?.path)?.name ?: ""
+            fileName = File(pathOz?.path)?.name ?: ""
+            view?.findViewById<TextView>(R.id.tv_file_name)?.text = fileName
             this.pathOz = pathOz
         }
     }

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileBottomSheet.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileBottomSheet.kt
@@ -33,6 +33,8 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
     private var fileType: String = ""
     private var uploadUrl: String = ""
     private var callback: String? = null
+    private var requestMethod: String? = null
+    private var fileUri: String? = null
 
     private lateinit var activityResultLauncher: ActivityResultLauncher<Intent>
     private lateinit var handlePathOz: HandlePathOz
@@ -48,6 +50,7 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
             fileType: String,
             uploadUrl: String,
             callback: String?,
+            requestMethod: String?,
             bottomSheetDialogInterface: BottomSheetDialogInterface
         ): UploadFileBottomSheet {
             val uploadResumeChatBottomSheet = UploadFileBottomSheet()
@@ -55,6 +58,7 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
             uploadResumeChatBottomSheet.fileType = fileType
             uploadResumeChatBottomSheet.uploadUrl = uploadUrl
             uploadResumeChatBottomSheet.callback = callback
+            uploadResumeChatBottomSheet.requestMethod = requestMethod
             uploadResumeChatBottomSheet.bottomSheetDialogInterface = bottomSheetDialogInterface
 
             return uploadResumeChatBottomSheet
@@ -81,6 +85,7 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
                 if (result.resultCode == Activity.RESULT_OK) {
                     val uri: Uri? = result.data?.data
+                    fileUri = uri.toString()
                     uri?.let { handlePathOz.getRealPath(it) }
                 }
             }
@@ -99,8 +104,9 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
 
             val serviceIntent = Intent(activity, UploadService::class.java)
             serviceIntent.putExtra("uploadUrl", uploadUrl)
-            serviceIntent.putExtra("filePath", pathOz.path)
+            serviceIntent.putExtra("fileUri", fileUri)
             serviceIntent.putExtra("callback", callback)
+            serviceIntent.putExtra("requestMethod", requestMethod)
             activity?.startService(serviceIntent)
 
         }

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileBottomSheet.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/UploadFileBottomSheet.kt
@@ -179,21 +179,27 @@ class UploadFileBottomSheet : BottomSheetDialogFragment(), HandlePathOzListener.
     private fun uploadImageFile() {
         val intent = Intent()
         intent.type = "image/*"
-        intent.action = Intent.ACTION_GET_CONTENT
+        intent.action = Intent.ACTION_OPEN_DOCUMENT
+        intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         activityResultLauncher.launch(Intent.createChooser(intent, "Select Image"))
     }
 
     private fun uploadVideoFile() {
         val intent = Intent()
         intent.type = "video/*"
-        intent.action = Intent.ACTION_GET_CONTENT
+        intent.action = Intent.ACTION_OPEN_DOCUMENT
+        intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         activityResultLauncher.launch(Intent.createChooser(intent, "Select Video"))
     }
 
     private fun uploadGeneralFile() {
         val intent = Intent()
         intent.type = "*/*"
-        intent.action = Intent.ACTION_GET_CONTENT
+        intent.action = Intent.ACTION_OPEN_DOCUMENT
+        intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         activityResultLauncher.launch(Intent.createChooser(intent, "Select File"))
     }
 

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/service/UploadService.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/service/UploadService.kt
@@ -1,7 +1,6 @@
 package `in`.workindia.rapidwebview.activities.service
 
 import `in`.workindia.rapidwebview.RapidWebViewNotificationHelper
-import `in`.workindia.rapidwebview.assetcache.RapidStorageUtility
 import `in`.workindia.rapidwebview.constants.BroadcastConstants
 import `in`.workindia.rapidwebview.network.RetrofitHelper
 import android.app.PendingIntent
@@ -14,6 +13,7 @@ import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.MutableLiveData
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -119,8 +119,7 @@ class UploadService : Service() {
         )
         val byteArray = fis?.readBytes()
 
-        val mediaType = RapidStorageUtility.getAssetMimeType(Uri.parse(fileUri)?.path.toString())
-            .toMediaTypeOrNull()
+        val mediaType: MediaType? = contentResolver.getType(Uri.parse(fileUri))?.toMediaTypeOrNull()
 
         if (byteArray != null && mediaType != null) {
             val requestBody: RequestBody = byteArray.toRequestBody(mediaType)

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/service/UploadService.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/activities/service/UploadService.kt
@@ -27,8 +27,8 @@ class UploadService : Service() {
 
     var fileUri: String = ""
     var uploadUrl: String = ""
-    var callback: String = ""
     var requestMethod: String = ""
+    var fileName: String = ""
 
     private var uploadStatusMutableLiveData: MutableLiveData<String> = MutableLiveData()
 
@@ -39,8 +39,8 @@ class UploadService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         fileUri = intent?.getStringExtra("fileUri") ?: ""
         uploadUrl = intent?.getStringExtra("uploadUrl") ?: ""
-        callback = intent?.getStringExtra("callback") ?: ""
         requestMethod = intent?.getStringExtra("requestMethod") ?: "POST"
+        fileName = intent?.getStringExtra("fileName") ?: ""
 
         if (fileUri.isBlank() || uploadUrl.isBlank()) {
             return START_NOT_STICKY
@@ -59,7 +59,8 @@ class UploadService : Service() {
             val intentBroadcast = Intent(BroadcastConstants.NATIVE_CALLBACK_ACTION)
             if (it.equals("success")) {
                 intentBroadcast.putExtra(BroadcastConstants.UPLOAD, "success")
-                intentBroadcast.putExtra(BroadcastConstants.CALLBACK, callback)
+                intentBroadcast.putExtra(BroadcastConstants.UPLOADED_FILE_NAME, fileName)
+                intentBroadcast.putExtra(BroadcastConstants.UPLOADED_URL, uploadUrl)
 
                 createNotification(
                     "Success",

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/constants/BroadcastConstants.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/constants/BroadcastConstants.kt
@@ -2,6 +2,8 @@ package `in`.workindia.rapidwebview.constants
 
 class BroadcastConstants {
     companion object {
+        const val UPLOADED_URL = "uploadedUrl"
+        const val UPLOADED_FILE_NAME = "uploadedFileName"
         const val NATIVE_CALLBACK_ACTION = "nativeActionListener"
         const val UPLOAD = "upload"
         const val PERMISSION = "permission"

--- a/RapidWebView/src/main/java/in/workindia/rapidwebview/network/RetrofitHelper.kt
+++ b/RapidWebView/src/main/java/in/workindia/rapidwebview/network/RetrofitHelper.kt
@@ -6,10 +6,7 @@ import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
-import retrofit2.http.Url
+import retrofit2.http.*
 
 /**
  * Singleton Retrofit class to create single instance of Retrofit
@@ -35,5 +32,8 @@ interface Urls {
     fun getAsset(@Url assetUrl: String): Call<ResponseBody>
 
     @POST()
-    fun uploadFile(@Url uploadUrl: String, @Body requestBody: RequestBody): Call<Void>
+    fun uploadFileViaPost(@Url uploadUrl: String, @Body requestBody: RequestBody): Call<Void>
+
+    @PUT()
+    fun uploadFileViaPut(@Url uploadUrl: String, @Body requestBody: RequestBody): Call<Void>
 }

--- a/samples/RapidWebViewSdkDocsSite/pages/docs/js-interface/functions.tsx
+++ b/samples/RapidWebViewSdkDocsSite/pages/docs/js-interface/functions.tsx
@@ -90,8 +90,8 @@ const FUNCTION_DOCS = [
   {
     id: 13,
     title: "Request permission",
-    description: 'To ask for android permission. It requires 3 parameters, an array containing all the permissions needed, rationale Text(text to show on permission dialog), and a callback. A callback is a reverse bridge between the Web and Android, it acts as a broadcast receiver from android to your website, it can be used to know whether your permission resulted in a success or a failure. If this information is not needed it can be passed as null.',
-    code: '.requestPermissions(["android.permission.CALL_PHONE"], "Permission required",null)',
+    description: 'To ask for android permission. It requires 2 parameters, an array containing all the permissions needed, rationale Text(text to show on permission dialog), and a callback. Callbacks from native can be used by using javascript event listener with the event "rapid-web-view-permission-listener" which will return object { detail: { "status" : "success","uploadUrl" : "$uploadUrl","uploadFileName" : "$fileName"} }',
+    code: '.requestPermissions(["android.permission.CALL_PHONE"], "Permission required")',
   },
   {
     id: 14,
@@ -108,8 +108,8 @@ const FUNCTION_DOCS = [
   {
     id: 16,
     title: "Open native file upload interface",
-    description: 'To upload a file using native file upload interface. It accepts 3 parameters, the file type, upload Url(where the file will be uploaded), and third a callback, this callback is either a javascript function or url to open once file upload activity is finished. Callback function can receive whether upload file succeeded by embedding params in the callback string. ',
-    code: '.uploadFile("doc", "www.example.com/uploadfile", "https://example.com/api/fileUploaded/?data=$params")',
+    description: 'To upload a file using native file upload interface. It accepts 3 parameters, the file type, upload Url(where the file will be uploaded), and third a method to either "PUT" or "POST", Callbacks from native can be used by using javascript event listener with the event "rapid-web-view-upload-listener" which will return object { detail: { "status" : "success","uploadUrl" : "$uploadUrl","uploadFileName" : "$fileName"} }',
+    code: '.uploadFile("doc", "www.example.com/uploadfile", "PUT|POST")',
   },
 ];
 


### PR DESCRIPTION
### Changed
- Changed UploadFile function in JavaScriptInterface
    - removed callback as a parameter
    - added upload type as a parameter (possible types : PUT and POST)
    - a callback will be generated everytime once there is a failure or a success
    - callback can be listened from javascript using event listener under the name "rapid-web-view-upload-listener"
    - under callback the javascript client will get object with following attribute { detail: { 'status' : "success",'uploadUrl' : '$uploadUrl','uploadFileName' : '$fileName' } }

- Changed Permission function in JavaScriptInterface
    - removed callback as a parameter
    - added permission type as a parameter (possible types : PUT and POST)
    - a callback will be generated everytime once there is a failure or a success
    - callback can be listened from javascript using event listener under the name "rapid-web-view-permission-listener"
    - under callback the javascript client will get object with following attribute { detail: { 'status' : "failure" } }

- Changed method to fetch file from Internal Storage